### PR TITLE
Change private to protected

### DIFF
--- a/include/mapping.hpp
+++ b/include/mapping.hpp
@@ -14,7 +14,7 @@
 
 class Mapping {
     
-private:
+protected:
     
     int  P; // # of processes
     // Array of nodes per rank.


### PR DESCRIPTION
Made internal variables of class Mapping protected not private in order subclasses to allow accessing them

La idea es que al crear una clase derivada que extienda la funcionalidad del Mapping (por ejemplo con un servicio que pueda cargar un mapping de un archivo), la subclase pueda acceder al tamaño y al vector. Otra alternativa sería modificar Mapping añadiendo métodos que permitan modificar el tamaño y el vector.