### PR TITLE
 Change behaviuor of Communicator::map() method 

### DIFF
--- a/include/mapping.hpp
+++ b/include/mapping.hpp
@@ -35,6 +35,8 @@ public:
     Mapping  (int P, int Q, int predef_map);
     ~Mapping ();
     
+    Mapping& operator = (const Mapping &m);
+    
     int getNode (int p);
     int getP();
     

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -51,10 +51,8 @@ Communicator *Communicator::create (int P, int *ranks) {
 
 
 void Communicator::map (Mapping *map) {
-    // 1. Deleting current mapping
-    delete this->mapping;
-    // 2. Changing by other one.
-    this->mapping = map;
+// TODO: Verify if size of mapping is equal to P
+    this->*mapping = *map; // assignation overloaded
 }
 
 

--- a/src/mapping.cpp
+++ b/src/mapping.cpp
@@ -69,6 +69,24 @@ Mapping::~Mapping () {
 }
 
 
+
+Mapping& Mapping::operator = (const Mapping &m) {
+   if (this != &m) {
+      if (m.P != this->getP()) { // new size
+          delete nodes;
+          this->P = m.P;
+          nodes = new int[this->P];
+      }
+      for (int i=0; i< this->P; i++)
+          this->nodes[i] = m.nodes[i];   
+   }
+   return *this;
+}
+
+
+
+
+
 int Mapping::getNode (int p) {
     return this->nodes[p];
 }
@@ -88,4 +106,3 @@ void Mapping::show () {
     cout << "]" << endl;
 
 }
-

--- a/tests/NBody/nbody.cpp
+++ b/tests/NBody/nbody.cpp
@@ -189,7 +189,7 @@ int main (int argc, const char * argv[]) {
     t = nbody_coll_rda (world, n_bodies);
     cout << "NBody RDA - COLL Homogeneous:    " << fixed << std::setprecision (3) << t << " usec." << endl;
 
-    
+    delete map;
     
     
     
@@ -220,6 +220,8 @@ int main (int argc, const char * argv[]) {
     cout << "NBody RDA - COLL Homogeneous:    " << fixed << std::setprecision (3) << t << " usec." << endl;
     
     
+    delete map;
+
     delete world;
     
     
@@ -255,6 +257,7 @@ int main (int argc, const char * argv[]) {
     t = nbody_coll_rda (irr_comm, n_bodies);
     cout << "NBody RDA - COLL Homogeneous:    " << fixed << std::setprecision (3) << t << " usec." << endl;
     
+    delete irr_map;
     delete irr_comm;
     
     

--- a/tests/ParallelAxBt/axbt.cpp
+++ b/tests/ParallelAxBt/axbt.cpp
@@ -166,7 +166,7 @@ int main (int argc, const char * argv[]) {
     cout << "Parallel AxB COLL Heterogeneous: " << fixed << std::setprecision (3) << t << " usec." << endl;
   
     
-    
+    delete map;
     
     
     // Homogeneous mapping with:
@@ -197,6 +197,8 @@ int main (int argc, const char * argv[]) {
     // 4. Parallel C=AxB^t using collectives. Heterogeneous version.
     t = parallelAxB_coll (world, N, b, nrows_het);
     cout << "Parallel AxB COLL Heterogeneous: " << fixed << std::setprecision (3) << t << " usec." << endl;
+
+    delete map;
 
     delete world;
 
@@ -236,6 +238,7 @@ int main (int argc, const char * argv[]) {
     t = parallelAxB_coll (irr_comm, N, b, nrows_het);
     cout << "Parallel AxB COLL Heterogeneous: " << fixed << std::setprecision (3) << t << " usec." << endl;
     
+    delete irr_map;
     delete irr_comm;
 
     

--- a/tests/Wave2D/wave2d.cpp
+++ b/tests/Wave2D/wave2d.cpp
@@ -137,7 +137,7 @@ int main (int argc, const char * argv[]) {
     t = wave2d_coll (world, N, b);
     cout << "Parallel AxB COLL Homogeneous:   " << fixed << std::setprecision (3) << t << " usec." << endl;
     
-    
+    delete map;
     
 
     
@@ -163,7 +163,8 @@ int main (int argc, const char * argv[]) {
     t = wave2d_coll (world, N, b);
     cout << "Parallel AxB COLL Homogeneous:   " << fixed << std::setprecision (3) << t << " usec." << endl;
     
-    
+    delete map;
+
     delete world;
 
     
@@ -199,6 +200,7 @@ int main (int argc, const char * argv[]) {
     t = wave2d_coll (irr_comm, N, b);
     cout << "Parallel AxB COLL Homogeneous:   " << fixed << std::setprecision (3) << t << " usec." << endl;
     
+    delete irr_map;
     delete irr_comm;
     
     

--- a/tests/colls/colls.cpp
+++ b/tests/colls/colls.cpp
@@ -59,8 +59,9 @@ double ex2_bcast (int P) {
     int size = 128 * 1024;
     TauLopCost *tc = bcast->evaluate(world, &size);
     double t = tc->getTime();
+
     delete tc;
-    
+    delete map;
     delete world;
     
     return t;
@@ -81,6 +82,7 @@ double ex3_bcast (int P) {
     double t = tc->getTime();
     
     delete tc;
+    delete map;
     delete world;
     
     return t;
@@ -185,6 +187,9 @@ int ex4_colls (int P) {
     delete (BcastBinomial *) bin;
     delete (AllgatherRDA  *) rda;
     delete (AllgatherRing *) ring;
+    delete map;
+    delete map_comm;
+    delete map_seq;
     delete world;
     return 0;
 }
@@ -220,6 +225,7 @@ int ex5_allgather () {
         cout << endl;
     }
     
+    delete map;
     delete comm;
     
     delete (AllgatherRDA  *) rda;

--- a/tests/communicators/creation.cpp
+++ b/tests/communicators/creation.cpp
@@ -66,6 +66,8 @@ int main (int argc, const char * argv[]) {
     
     
     // 5. Delete objects
+    delete map;
+    delete map_comm;
     delete comm;
     delete world;
     return 0;

--- a/tests/communicators/simple.cpp
+++ b/tests/communicators/simple.cpp
@@ -41,6 +41,7 @@ int main (int argc, const char * argv[]) {
     
     // 5. Delete objects
     delete (BcastBinomial *)bin;
+    delete map;
     delete world;
     return 0;
 }


### PR DESCRIPTION
Now Communicator::map(*newMap) method stores A COPY of newMap (and not a REFERENCE to newMap)